### PR TITLE
Add (Fr)Agile slide links

### DIFF
--- a/fragile-how-agile-falls-apart-and-what-you-can-do-to-hold-it-all-together/README.md
+++ b/fragile-how-agile-falls-apart-and-what-you-can-do-to-hold-it-all-together/README.md
@@ -1,0 +1,9 @@
+# (Fr)Agile: How Agile Falls Apart (and what you can do to hold it all together)
+
+Presented by Sean Killeen @ TechBash 2018.
+
+Up to date slides available at <https://seankilleen.com/Presentations/2018-10_Fragile>.
+
+You can check out the presentation from <http://github.com/SeanKilleen/Presentations>. I'd post it here but I have font-awesome and some other stuff as part of the repo so I can pull it down locally for off-line scenarios; figured I'd save the bytes on this repo. If you want it here, feel free to make a PR and add it; you have my full permission. :)
+
+Thanks for a great year, TechBash!


### PR DESCRIPTION
Rather than add all of the common files that I used for this RevealJS presentation, I link to my repo in a `README` file. 

If anyone prefers, I can I add all the files; it's just a local copy of RevealJS and font-awesome. But figured a link would suffice for now since it's already OSS.